### PR TITLE
Remove boolean from --tar-archive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
 | num_cpu                      | 10                                   | Number of logical CPUs to be used for secret scanning (default 10)                         | Integer | No       | 10          |
 | show_failed_issues_only      | n/a                                  | Show only failed issues                                                                    | Boolean | No       | false       |
 | custom_secret_controls       | custom_rules.yaml                    | Path to custom secret controls file                                                        | String  | No       | N/A         |
-| tar_archive                  | n/a                                  | Scan a tar archived image. Input should be the path of the image .tar file                 | Boolean | No       | false       |
+| tar_archive                  | n/a                                  | Scan a tar archived image. Input `image` should be the path of the image .tar file         | Boolean | No       | false       |
 | oci                          | n/a                                  | Scan an OCI image                                                                          | Boolean | No       | false       |
 | skip_remote_lookup           | false                                | Do not perform remote lookups for dependency information during the scan.                  | Boolean | No       | false       |
 | display_name                 | custom-display-name                  | Scan log display name (on Orca platform)                                                   | String  | No       | N/A         |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,7 +83,7 @@ function set_container_scan_flags() {
     SCAN_FLAGS+=("${INPUT_IMAGE}")
   fi
   if [ "${INPUT_TAR_ARCHIVE}" ]; then
-    SCAN_FLAGS+=(--tar-archive "${INPUT_TAR_ARCHIVE}")
+    SCAN_FLAGS+=(--tar-archive)
   fi
   if [ "${INPUT_TIMEOUT}" ]; then
     SCAN_FLAGS+=(--timeout "${INPUT_TIMEOUT}")


### PR DESCRIPTION
Tar images scans are failing with error: `Error: "orca-cli image scan" accepts 1 arg(s), received 2: [./image.tar, true]`

This Github Actions is producing: `orca-cli--project-key proj_key image scan ./image.tar --tar-archive true`
Based on the documentation Orca CLI input should be: `orca-cli--project-key proj_key image scan ./image.tar --tar-archive`

By removing boolean from the flag we remove second argument from the list provided in error.


